### PR TITLE
CORE-585 Improve performance of :folder-listing query

### DIFF
--- a/src/clj_icat_direct/icat.clj
+++ b/src/clj_icat_direct/icat.clj
@@ -1,7 +1,6 @@
 (ns clj-icat-direct.icat
   (:use [clojure.java.io :only [file]])
-  (:require [clojure.string :as string]
-            [korma.db :as db]
+  (:require [korma.db :as db]
             [korma.core :as k]
             [clj-icat-direct.queries :as q])
   (:import [clojure.lang ISeq Keyword]))
@@ -179,7 +178,7 @@
    Returns:
      It returns a sequence of paths."
   [^String user ^String zone ^String folder-path]
-  (map :full_path (run-simple-query :folder-listing user zone folder-path)))
+  (map :full_path (run-simple-query :folder-listing folder-path folder-path user zone)))
 
 
 (defn- fmt-info-type


### PR DESCRIPTION
The `:folder-listing` query was creating a CTE that scanned every permission in the ICAT for the given user, which was very slow in production with many items in the ICAT.

This update, suggested by @ianmcorvidae, will only scan permissions under the folder required for the listing.