### PR TITLE
Performance and user fetching

### DIFF
--- a/src/clj_icat_direct/icat.clj
+++ b/src/clj_icat_direct/icat.clj
@@ -62,6 +62,13 @@
   (with-icat-transaction
     (apply run-stuff queries)))
 
+(defn user
+  "Get a representation of a user with their ID, username, type name, zone, 'info', 'comment', and create/modify timestamps."
+  [username zone]
+  (->> (q/mk-user username zone)
+       (apply run-query-string)
+       first))
+
 (defn user-group-ids
   "Get user group IDs, including the user's ID"
   [user zone]

--- a/src/clj_icat_direct/queries.clj
+++ b/src/clj_icat_direct/queries.clj
@@ -253,6 +253,10 @@
                    c.modify_ts"))
 
 
+(defn mk-user
+  [user zone]
+  [(str "SELECT user_id, user_name, user_type_name, zone_name, user_info, r_comment, create_ts, modify_ts FROM r_user_main WHERE user_name = ? AND zone_name = ?") user zone])
+
 (defn mk-groups
   [user zone & placeholder-vec?]
   (let [base "SELECT *

--- a/src/clj_icat_direct/queries.clj
+++ b/src/clj_icat_direct/queries.clj
@@ -451,13 +451,12 @@
       access_type_id - the ICAT DB Id indicating the user's level of access to the file"
   [& {:keys [user zone parent-path info-type-cond sort-column sort-direction limit offset groups-table-query]}]
   (let [group-query "SELECT group_user_id FROM groups"]
-    [[(mk-temp-table "groups" (or groups-table-query (mk-groups user zone)))]
-     [(analyze "groups")]
-     [(mk-temp-table "objs" (mk-unique-objs-in-coll parent-path))]
+    [[(mk-temp-table "objs" (mk-unique-objs-in-coll parent-path))]
      [(analyze "objs")]
      [(mk-temp-table "file_avus" (mk-obj-avus "SELECT data_id FROM objs"))]
      [(analyze "file_avus")]
-     [(str (mk-files-in-folder parent-path group-query info-type-cond "objs" "file_avus" true) "
+     [(str "WITH groups AS (" (or groups-table-query (mk-groups user zone)) ") "
+           (mk-files-in-folder parent-path group-query info-type-cond "objs" "file_avus" true) "
            ORDER BY " sort-column " " sort-direction "
            LIMIT ?
            OFFSET ?") limit offset]]))


### PR DESCRIPTION
Adds a basic "get user" to this library for clj-irods to use, which means we can do `user-exists?` type validations without needing a jargon connection. Also, copies a previous optimization to a place I missed before.