### PR TITLE
CORE-1174: modified `paged-folder-listing` to create a new database transaction by default.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /lib
 /classes
 /native
+/.eastwood
 /.lein-failures
 /checkouts
 .lein-deps-sum

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,9 @@
             :url "http://www.iplantcollaborative.org/sites/default/files/iPLANT-LICENSE.txt"}
   :deploy-repositories [["releases" :clojars]
                         ["snapshots" :clojars]]
-  :plugins [[test2junit "1.2.2"]]
+  :plugins [[jonase/eastwood "0.3.11"]
+            [test2junit "1.2.2"]]
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [korma "0.4.3"]
-                 [org.postgresql/postgresql "9.4.1212"]])
+                 [org.postgresql/postgresql "9.4.1212"]]
+  :eastwood {:exclude-linters [:def-in-def :unlimited-use]})


### PR DESCRIPTION
This fixes a problem that occurs when hitting the `path-list-creator` endpoint in `data-info`.

Before the change:

```
$ curl -sH "Content-Type: application/json" "http://data-info/path-list-creator?user=sarahr&dest=/iplant/home/sarahr/1.htl&name-pattern=.clj&folders-only=false&recursive=true&path-list-info-type=ht-analysis-path-list" -d '{"paths":["/iplant/home/sarahr/foo"]}' | jq .
{
  "error_code": "ERR_UNCHECKED_EXCEPTION",
  "message": "ERROR: relation \"objs\" does not exist"
}
```

After the change:

```
$ curl -sH "Content-Type: application/json" "http://localhost:60000/path-list-creator?user=sarahr&dest=/iplant/home/sarahr/1.htl&name-pattern=.clj&folders-only=false&recursive=true&path-list-info-type=ht-analysis-path-list" -d '{"paths":["/iplant/home/sarahr/foo"]}' | jq .
{
  "file": {
    "infoType": "ht-analysis-path-list",
    "path": "/iplant/home/sarahr/1.htl",
    "share-count": 0,
    "date-created": 1606171622000,
    "md5": "0e7cb4c40a54f1739bfcd2c47ae5d305",
    "permission": "own",
    "date-modified": 1606171622000,
    "type": "file",
    "file-size": 1141,
    "label": "1.htl",
    "id": "cdfd7634-2ddd-11eb-939f-90e2ba675364",
    "content-type": "text/plain"
  }
}
```
