### PR TITLE
CORE-2005: folder listing performance improvements.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 /.eastwood
 /.lein-failures
 /checkouts
+.clj-kondo
+.lsp
 .lein-deps-sum
 .lein-plugins
 /.classpath

--- a/src/clj_icat_direct/queries.clj
+++ b/src/clj_icat_direct/queries.clj
@@ -180,18 +180,20 @@
                                       WHERE d2.data_id = d1.data_id)"))
 
 
-(defn mk-colls-in-coll
-  [parent-path]
-  (str "SELECT *
-          FROM r_coll_main AS c1
-          WHERE c1.parent_coll_name = '" parent-path "'"))
-
 (defn- mk-obj-avus
   [obj-ids-query]
   (str "SELECT object_id, meta_attr_value, meta_attr_name
           FROM r_objt_metamap AS o JOIN r_meta_main AS m ON o.meta_id = m.meta_id
           WHERE o.object_id = ANY(ARRAY(" obj-ids-query "))"))
 
+(defn- mk-coll-avus
+  [parent-path]
+  (mk-obj-avus (str "SELECT coll_id FROM r_coll_main WHERE parent_coll_name = '" parent-path "'")))
+
+(defn mk-combined-avus
+  [objs-table parent-path]
+  (mk-obj-avus (str "SELECT data_id FROM objs UNION SELECT coll_id FROM r_coll_main WHERE parent_coll_name = '"
+                    parent-path "'")))
 
 (defn- mk-file-types
   [avus-cte]
@@ -359,6 +361,7 @@
        (h/from [:r_objt_access :p])
        (h/join [:r_user_main :u] [:using :user_id]
                [:object-lookup :o] [:using :object_id]))))
+
 
 (defn- mk-count-colls-in-coll
   [parent-path group-ids-query & {:keys [cond] :or {cond "TRUE"}}]
@@ -586,9 +589,7 @@
       access_type_id - the ICAT DB Id indicating the user's level of access to the folder
       data_checksum  - nil for collections, the MD5 checksum of the file for data objects"
   [& {:keys [user zone parent-path sort-column sort-direction limit offset groups-table-query]}]
-  [[(mk-temp-table "colls" (mk-colls-in-coll parent-path))]
-   [(analyze "colls")]
-   [(mk-temp-table "coll_avus" (mk-obj-avus "SELECT coll_id FROM colls"))]
+  [[(mk-temp-table "coll_avus" (mk-coll-avus parent-path))]
    [(analyze "coll_avus")]
    [(str "WITH groups AS (" (or groups-table-query (mk-groups user zone)) ")
        " (mk-folders-in-folder parent-path "SELECT group_user_id FROM groups" true "coll_avus") "
@@ -630,17 +631,13 @@
       data_checksum  - nil for collections, the MD5 checksum of the file for data objects"
   [& {:keys [user zone parent-path info-type-cond sort-column sort-direction limit offset groups-table-query]}]
   (let [group-query   "SELECT group_user_id FROM groups"
-        folders-query (mk-folders-in-folder parent-path group-query false "coll_avus")
+        folders-query (mk-folders-in-folder parent-path group-query false "avus")
         files-query   (mk-files-in-folder parent-path group-query info-type-cond "objs"
-                                          "file_avus" false)]
+                                          "avus" false)]
     [[(mk-temp-table "objs" (mk-unique-objs-in-coll parent-path))]
      [(analyze "objs")]
-     [(mk-temp-table "file_avus" (mk-obj-avus "SELECT data_id FROM objs"))]
-     [(analyze "file_avus")]
-     [(mk-temp-table "colls" (mk-colls-in-coll parent-path))]
-     [(analyze "colls")]
-     [(mk-temp-table "coll_avus" (mk-obj-avus "SELECT coll_id FROM colls"))]
-     [(analyze "coll_avus")]
+     [(mk-temp-table "avus" (mk-combined-avus "objs" parent-path))]
+     [(analyze "avus")]
      [(str "WITH groups AS (" (or groups-table-query (mk-groups user zone)) ") "
            "SELECT *, COUNT(*) OVER () AS total_count
             FROM (" folders-query " UNION " files-query ") AS t

--- a/src/clj_icat_direct/queries.clj
+++ b/src/clj_icat_direct/queries.clj
@@ -192,8 +192,9 @@
 
 (defn mk-combined-avus
   [objs-table parent-path]
-  (mk-obj-avus (str "SELECT data_id FROM objs UNION SELECT coll_id FROM r_coll_main WHERE parent_coll_name = '"
-                    parent-path "'")))
+  (mk-obj-avus (str "SELECT data_id FROM " objs-table
+                    " UNION "
+                    "SELECT coll_id FROM r_coll_main WHERE parent_coll_name = '" parent-path "'")))
 
 (defn- mk-file-types
   [avus-cte]


### PR DESCRIPTION
The purpose of this PR is to improve folder listings in some cases where the listing takes much longer than we would expect. The results were a little mixed, but the one case that we were trying to fix improved dramatically.

Before improvements:

| Case Description | Time |
| ---- | ---- |
| File and folder listing for problem account | 100 seconds |
| File and folder listing for non-problem account | 3.5 seconds |
| Folder listing only for problem account | 1.7 seconds |
| Folder listing only for non-problem account | 1.4 seconds |

After improvements:

| Case Description | Time |
| ---- | ---- |
| File and folder listing for problem account | 5.1 seconds |
| File and folder listing for non-problem account | 4.1 seconds |
| Folder listing only for problem account | 4.9 seconds |
| Folder listing only for non-problem account | 4.0 seconds |

The small performance decreases for everything but the problem case is suboptimal, but fixing the problem case is a higher priority at this time. We can spend some more time optimizing this some more later.