### PR TITLE
CORE-2008: fixed an error that was occuring when trying to look up th…

### DIFF
--- a/src/clj_icat_direct/queries.clj
+++ b/src/clj_icat_direct/queries.clj
@@ -295,9 +295,8 @@
                               [:coll_name :path])
                     (h/from :r_coll_main)
                     (h/join :objid [:= :r_coll_main.coll_id :objid.object_id]))
-                (-> (h/select [:meta_attr_value :uuid]
-                              [[:raw "coll_name || '/' || data_name"] :path])
-                    h/distinct
+                (-> (h/select-distinct [:meta_attr_value :uuid]
+                                       [[:raw "coll_name || '/' || data_name"] :path])
                     (h/from :r_data_main)
                     (h/join :r_coll_main [:using :coll_id]
                             :objid [:= :r_data_main.data_id :objid.object_id]))]}))


### PR DESCRIPTION
…e path corresponding to a UUID

This fixes an error that was occurring when trying to find the path corresponding to a UUID:

```
1. Unhandled clojure.lang.ExceptionInfo
   These SQL clauses are unknown or have nil values: :distinct(perhaps you need [:lift {:distinct ...}] here?)
   {:distinct nil}
                  sql.cljc: 1582  honey.sql$format_dsl/invokeStatic
                  sql.cljc: 1558  honey.sql$format_dsl/doInvoke
                  sql.cljc:  649  honey.sql$format_on_set_op$fn__10331/invoke
                  core.clj: 2770  clojure.core/map/fn
                  core.clj:  139  clojure.core/seq
                  core.clj: 6887  clojure.core/reduce
                  core.clj: 6869  clojure.core/reduce
                  sql.cljc:  641  honey.sql$reduce_sql/invokeStatic
                  sql.cljc:  640  honey.sql$reduce_sql/invoke
                  sql.cljc:  649  honey.sql$format_on_set_op/invokeStatic
                  sql.cljc:  648  honey.sql$format_on_set_op/invoke
                  sql.cljc: 1574  honey.sql$format_dsl$fn__10866/invoke
     PersistentVector.java:  343  clojure.lang.PersistentVector/reduce
                  core.clj: 6886  clojure.core/reduce
                  core.clj: 6869  clojure.core/reduce
                  sql.cljc: 1568  honey.sql$format_dsl/invokeStatic
                  sql.cljc: 1558  honey.sql$format_dsl/doInvoke
                  sql.cljc: 2108  honey.sql$format/invokeStatic
                  sql.cljc: 2042  honey.sql$format/invoke
                  sql.cljc: 2057  honey.sql$format/invokeStatic
                  sql.cljc: 2042  honey.sql$format/invoke
                      REPL:  288  clj-icat-direct.queries/mk-paths-for-uuids
                      REPL:  286  clj-icat-direct.queries/mk-paths-for-uuids
               queries.clj:  307  clj-icat-direct.queries/mk-path-for-uuid
               queries.clj:  305  clj-icat-direct.queries/mk-path-for-uuid
                  icat.clj:   81  clj-icat-direct.icat/path-for-uuid
                  icat.clj:   79  clj-icat-direct.icat/path-for-uuid
                      REPL:    7  clj-icat-direct.test/test-path-for-uuid
                      REPL:    5  clj-icat-direct.test/test-path-for-uuid
                      REPL:    9  clj-icat-direct.test/eval13811
```

After making the change, the error no longer occurs:

<img width="732" alt="image" src="https://github.com/user-attachments/assets/a5020bd7-007b-4cab-85e4-256f45ff3ce6">
